### PR TITLE
fix broken link

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Shortcut:
 - https://apiv1.snoozeds.repl.co
 - https://shot-on-iphone.studio/api/video
 - https://api.kazdev.ml
-- https://app.resetxd.repl.co
+- https://api.resetxd.xyz
 - https://cryptons-api.herokuapp.com
 - https://spapi.ga
 - https://vslapi.cf/endpoints


### PR DESCRIPTION
the api link was/will be change , https://app.resetxd.repl.co was changed to https://resapi.up.railway.app which will again be changed to api.resetxd.xyz soon. 

though api.resetxd.xyz isnt yet made but the domain is available to me and will get change by 1july